### PR TITLE
Fix Makefile and edit README 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,8 @@ ifndef OO_PS4_TOOLCHAIN
     $(error OO_PS4_TOOLCHAIN is undefined)
 endif
 
-CC := clang-10
-LD := ld.lld-10
+CC := clang
+LD := ld.lld
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
@@ -48,7 +48,7 @@ endif
 
 
 CFLAGS := -target x86_64-scei-ps4-elf -funwind-tables \
-          -fuse-init-array -isysroot $(OO_PS4_TOOLCHAIN) \
+        	-isysroot $(OO_PS4_TOOLCHAIN) \
 	  -isystem $(OO_PS4_TOOLCHAIN)/include -I. -Wall \
 	  -DTITLE_ID='"$(TITLE_ID)"' -g
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ tiny-ps4-shell is a small telnet server for the PS4 with a couple of basic
 UNIX-like commands, e.g., cd, mkdir, stat, etc.
 
 ## Building
-Assuming you have [the Open Orbis SDK][openorbis] (tested with v0.5.2)
+Assuming you have [the Open Orbis SDK][openorbis] (tested with v0.5.2) and imagemagick (for icon conversion)
 installed on you machine, tiny-ps4-shell can be compiled using the following
 two commands:
 


### PR DESCRIPTION
FIX: Use "clang" as compiler name, as the OpenOrbis supports up to clang-14
ADD: Adds the "imagemagic" require for the app icon convertion (using the convert tool) works

`-fuse-init-array` is not used anymore for recent clang versions, see https://github.com/OpenOrbis/OpenOrbis-PS4-Toolchain/issues/100